### PR TITLE
Use CALayer instead of UIImageView layer

### DIFF
--- a/JSQMessagesViewController/Factories/JSQMessagesMediaViewBubbleImageMasker.m
+++ b/JSQMessagesViewController/Factories/JSQMessagesMediaViewBubbleImageMasker.m
@@ -73,11 +73,20 @@
 {
     NSParameterAssert(view != nil);
     NSParameterAssert(image != nil);
-    
+
     UIImageView *imageViewMask = [[UIImageView alloc] initWithImage:image];
     imageViewMask.frame = CGRectInset(view.frame, 2.0f, 2.0f);
-    
-    view.layer.mask = imageViewMask.layer;
+
+    CALayer *layer = [[CALayer alloc] init];
+    layer.contents = (id) imageViewMask.image.CGImage;
+    layer.contentsScale = imageViewMask.image.scale;
+    layer.contentsCenter = CGRectMake(
+                                      ((image.size.width / 2) - 1) / image.size.width,
+                                      ((image.size.height / 2) - 1) / image.size.height,
+                                      1 / image.size.width,
+                                      1 / image.size.height);
+    layer.frame = imageViewMask.frame;
+    view.layer.mask = layer;
 }
 
 @end


### PR DESCRIPTION
## What's in this pull request?
iOS14でチャットの画像が表示されない現象がり、原因として
https://developer.apple.com/forums/thread/656554
↑の通り直接UIImageView layerを使うとうまくmask処理が行われていない様でした。

対応としてCALayerを間に挟んで対応するようにしました。
